### PR TITLE
mpfr: Fix versioning

### DIFF
--- a/mpfr/PKGBUILD
+++ b/mpfr/PKGBUILD
@@ -3,7 +3,10 @@
 pkgname=('mpfr' 'mpfr-devel')
 _pkgver=3.1.4
 _patchlevel=
-pkgver=${_pkgver}.${_patchlevel}
+pkgver=${_pkgver}
+if [ -n "${_patchlevel}" ]; then
+  pkgver+=.${_patchlevel}
+fi
 #pkgver=${_pkgver}
 pkgrel=1
 pkgdesc="Multiple-precision floating-point library"


### PR DESCRIPTION
mpfr package had invalid version 3.1.4.-3 when it should have been
3.1.4-3. This was caused because an empty _patchlevel was set appended
to the package version separated with a dot.

This commit changes the package versioning so that the _patchlevel is
appended to the package version only if it isn't empty.

Similar commit 0c86b53 was done to mpfr package in MINGW-packages.
